### PR TITLE
feat: integrate service fee into donation calculations

### DIFF
--- a/src/app/cause/[cause_id]/payment/page.tsx
+++ b/src/app/cause/[cause_id]/payment/page.tsx
@@ -12,11 +12,12 @@ export default async function DonatePage({ params }: { params: { cause_id: strin
   if (!user) redirect('/login')
   const cause = await getCauseById(params.cause_id)
   if (!cause) redirect('/')
+  const serviceFee = process.env.NEXT_PUBLIC_REFREEG_SERVICE_FEE
     return (
         <div className="min-h-screen bg-gray-100">
             <Navbar userSession={!!sessionId} profile={user?.profileImage === "" ? undefined : user?.profileImage} />
             <div className="max-w-3xl mx-auto p-4 space-y-5 bg-white shadow-md rounded-lg my-10">
-                <DonationForm cause={cause} user={user} />
+                <DonationForm cause={cause} user={user} serviceFee={parseFloat(serviceFee!)} />
             </div>
         </div>
     );

--- a/src/components/DonationForm.tsx
+++ b/src/components/DonationForm.tsx
@@ -8,10 +8,9 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Cause, User } from "@/lib/type";
 import PaymentButton from "./PaymentButton";
 
-export default function DonationForm({ cause, user }: { cause: Cause, user: User }) {
+export default function DonationForm({ cause, user, serviceFee }: { cause: Cause, user: User, serviceFee: number }) {
   const [donation, setDonation] = useState(0);
   const [isAnonymous, setIsAnonymous] = useState(false);
-  const serviceFee = 100;
   const totalAmount = donation + serviceFee;
   const PayStackFee = 100;
 

--- a/src/lib/firebase/actions/transaction.ts
+++ b/src/lib/firebase/actions/transaction.ts
@@ -18,10 +18,10 @@ export const logTransaction = async ({
     transactionId: string;
 }) => {
     try {
-        // 
+        const serviceFee = process.env.NEXT_PUBLIC_REFREEG_SERVICE_FEE
         const cause = await getCauseById(causeId)
         const currentRaised = parseFloat(cause!.raisedAmount.toString());
-        const newAmount = parseFloat(amount.toString());
+        const newAmount = parseFloat(amount.toString()) - parseFloat(serviceFee!);
         await updateCauseById(causeId, {
             ...cause,
             raisedAmount: currentRaised + newAmount
@@ -54,20 +54,12 @@ export const getCauseTransactions = async (causeId: string): Promise<Transaction
         const donationsRef = collection(db, `causes/${causeId}/donated`);
         const querySnapshot = await getDocs(donationsRef);
 
-        const transactions = querySnapshot.docs.map(doc => {
-            const data = doc.data();
-            // Validate and map each field explicitly
-            return {
-                id: doc.id,
-                amount: typeof data.amount === 'number' ? data.amount : 0,
-                causeId: causeId,
-                userId: typeof data.userId === 'string' ? data.userId : '',
-                timestamp: typeof data.timestamp === 'string' ? data.timestamp : new Date().toISOString(),
-                customer_name: typeof data.customer_name === 'string' ? data.customer_name : 'Anonymous'
-            };
-        });
+        const transactions = querySnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        }));
 
-        return transactions;
+        return transactions as Transaction[];
     } catch (error) {
         console.error("Error fetching cause transactions:", error);
         throw error;

--- a/src/lib/services/paystack.ts
+++ b/src/lib/services/paystack.ts
@@ -32,12 +32,13 @@ const Paystack = {
       const requestData = {
         currency: "NGN",
         email: data.email,
-        amount: Math.round((data.amount + data.serviceFee )* 100), // Ensure amount is rounded to avoid floating point issues
+        amount: Math.round((data.amount + data.serviceFee) * 100), // Ensure amount is rounded to avoid floating point issues
         callback_url: `${baseUrl}/payment/verify`,
         split: {
           type: "flat",
           bearer_type: "account",
           subaccounts: data.subaccounts || [], // Ensure subaccounts is always an array
+          transaction_charge: data.serviceFee
         },
         metadata: {
           user_id: data.id,


### PR DESCRIPTION
- Updated DonationForm to accept serviceFee as a prop, ensuring accurate total amount calculations.
- Adjusted transaction logging to deduct service fee from the donation amount before updating the cause's raised amount.
- Enhanced Paystack service integration to include service fee in the transaction charge, improving payment accuracy.